### PR TITLE
Number tile extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Pages are defined in a list of hash-maps like this:
              :params {:heading "Awesomeness"
                       :descr   "OVER"
                       :num     9000}}
+            {:type   :number
+             :params {:heading "Offset"
+                      :descr   "Last offset for stats"
+                      :target  (dsl/max-series "app-serv-#{env}.*.metrics.stats.offset")}}
             {:type   :plain-html
              :params [:div {:class "col"}
                       [:h2 "CUSTOM HTML"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject de.otto/oscillator "0.2.20"
+(defproject de.otto/oscillator "0.2.21"
             :description "A Clojure library that lets you create dashboards with
                          interactive charts to monitor applications in multiple environments."
             :url "https://github.com/otto-de/oscillator"

--- a/src-cljs/monitor/number.cljs
+++ b/src-cljs/monitor/number.cljs
@@ -1,0 +1,29 @@
+(ns monitor.number
+  (:require
+    [dommy.core :as d]
+    [dommy.core :refer-macros [sel sel1]]))
+
+(def jquery (js* "$"))
+
+(defn update-number [el]
+  (.get jquery (.getAttribute el "data-url")
+        (fn [data]
+          (->> (first (first (aget (first data) "datapoints")))
+              (d/set-html! (first (sel el :.focus))))
+          "json")))
+
+(defn refresh-number [number]
+  (js/setInterval
+    (fn []
+      (update-number number))
+    3000))
+
+(defn on-document-ready []
+  (doseq [el (sel :.col.number.target)]
+    (refresh-number el)))
+
+(.addEventListener js/document "DOMContentLoaded"
+                   on-document-ready)
+
+
+

--- a/src/de/otto/oscillator/view/component.clj
+++ b/src/de/otto/oscillator/view/component.clj
@@ -44,8 +44,15 @@
    [:h2 heading]
    [:img {:src src}]])
 
-(defn number [{:keys [heading descr num]}]
-  [:div {:class "col number"}
-   [:h2 heading]
-   [:div {:class "descr"} descr]
-   [:div {:class "focus"} num]])
+(defn number [{:keys [heading descr num target]} page-config url-params]
+  (if (nil? target)
+    [:div {:class "col number"}
+     [:h2 heading]
+     [:div {:class "descr"} descr]
+     [:div {:class "focus"} num]]
+    (let [chart-def (merge {:target target} url-params)]
+      [:div {:class    "col number target"
+             :data-url (url/json-url page-config chart-def)}
+       [:h2 heading]
+       [:div {:class "descr"} descr]
+       [:div {:class "focus"} num]])))

--- a/src/de/otto/oscillator/view/page.clj
+++ b/src/de/otto/oscillator/view/page.clj
@@ -25,7 +25,7 @@
                  chart-def (chart-def chart-def-lookup-fun chart-name (:env url-params))]
              (vc/link-to-chart page-config chart-def chart-name url-params))
     :image (vc/image params)
-    :number (vc/number params)
+    :number (vc/number params page-config url-params)
     :plain-html params
     :html-fn (params page-config url-params)
     :pie-chart (render-pie-chart params page-config url-params)))

--- a/test/de/otto/oscillator/view/page_test.clj
+++ b/test/de/otto/oscillator/view/page_test.clj
@@ -33,6 +33,18 @@
               [:h2 "somehead"]
               [:div {:class "descr"} "some-descr"]
               [:div {:class "focus"} 123]]
+             (#'page/build-tile a-tile-config nil nil nil)))))
+
+  (testing "should render a number with target"
+    (let [a-tile-config {:type   :number
+                         :params {:heading "somehead"
+                                  :descr   "some-descr"
+                                  :target  "some.target"}}]
+      (is (= [:div {:class "col number target"
+                    :data-url "render/?target=some.target&format=json"}
+              [:h2 "somehead"]
+              [:div {:class "descr"} "some-descr"]
+              [:div {:class "focus"} nil]]
              (#'page/build-tile a-tile-config nil nil nil))))))
 
 


### PR DESCRIPTION
Number tiles are now able to display single values from graphite. You can specify a graphite target via :target property via number tile params.