### PR TITLE
number js now uses the latest value

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject de.otto/oscillator "0.2.22"
+(defproject de.otto/oscillator "0.2.23"
             :description "A Clojure library that lets you create dashboards with
                          interactive charts to monitor applications in multiple environments."
             :url "https://github.com/otto-de/oscillator"

--- a/src-cljs/monitor/number.cljs
+++ b/src-cljs/monitor/number.cljs
@@ -8,7 +8,8 @@
 (defn first-datapoint [data]
   (-> (first data)
       (aget "datapoints")
-      (ffirst)))
+      (last)
+      (first)))
 
 (defn formatter-string [el]
   (or (.getAttribute el "data-formatter") ".4s"))
@@ -19,19 +20,20 @@
          (formatter)
          (d/set-html! (sel1 el :.focus)))))
 
-(defn fetch-and-update-number [el]
-  (.get jquery (.getAttribute el "data-url")
-        (partial update-number el)))
+(defn fetch-and-update-number [elements]
+  (doseq [el elements]
+    (.get jquery (.getAttribute el "data-url")
+          (partial update-number el))))
 
-(defn refresh-number [number]
+(defn refresh-number [elements]
+  (fetch-and-update-number elements)
   (js/setInterval
     (fn []
-      (fetch-and-update-number number))
+      (fetch-and-update-number elements))
     3000))
 
 (defn on-document-ready []
-  (doseq [el (sel :.col.number.target)]
-    (refresh-number el)))
+  (refresh-number (sel :.col.number.target)))
 
 (.addEventListener js/document "DOMContentLoaded"
                    on-document-ready)

--- a/test/de/otto/oscillator/view/page_test.clj
+++ b/test/de/otto/oscillator/view/page_test.clj
@@ -18,7 +18,7 @@
   (testing "should render an image"
     (let [a-tile-config {:type   :image
                          :params {:heading "somehead"
-                                  :src "some-src"}}]
+                                  :src     "some-src"}}]
       (is (= [:div {:class "col image"}
               [:h2 "somehead"]
               [:img {:src "some-src"}]]
@@ -27,8 +27,8 @@
   (testing "should render a number"
     (let [a-tile-config {:type   :number
                          :params {:heading "somehead"
-                                  :descr "some-descr"
-                                  :num 123}}]
+                                  :descr   "some-descr"
+                                  :num     123}}]
       (is (= [:div {:class "col number"}
               [:h2 "somehead"]
               [:div {:class "descr"} "some-descr"]
@@ -40,8 +40,9 @@
                          :params {:heading "somehead"
                                   :descr   "some-descr"
                                   :target  "some.target"}}]
-      (is (= [:div {:class "col number target"
-                    :data-url "render/?target=some.target&format=json"}
+      (is (= [:div {:class          "col number target"
+                    :data-url       "render/?target=some.target&format=json"
+                    :data-formatter nil}
               [:h2 "somehead"]
               [:div {:class "descr"} "some-descr"]
               [:div {:class "focus"} nil]]


### PR DESCRIPTION
- version number increased
- number js now uses the latest value from datapoint
- tile elements will be delegated to call setInterval only one time
- page_test fixed
